### PR TITLE
feat: purge command

### DIFF
--- a/hacksquad_discordpy/main.py
+++ b/hacksquad_discordpy/main.py
@@ -31,6 +31,10 @@ async def sync(ctx):
     await bot.tree.sync()
     await ctx.send("Synced")
 
+@bot.command()
+@commands.has_permissions(administrator=True)
+async def purge(ctx, amount=5):
+    await ctx.channel.purge(limit=amount)
 
 bot.run(my_secret)
 


### PR DESCRIPTION
Added a command to purge/delete desired number of messages from a channel.
  -Need to have admin permissions.
  -By default it will delete last 5 messages (including the command).